### PR TITLE
update get_ddh_records_status()

### DIFF
--- a/R/get_ddh_datasets_list.R
+++ b/R/get_ddh_datasets_list.R
@@ -17,7 +17,8 @@ get_ddh_datasets_list <- function(root_url = dkanr::get_url(),
       'field_wbddh_reference_id',
       'field_wbddh_data_class',
       'field_wbddh_modified_date',
-      'field_ddh_harvest_sys_id'
+      'field_ddh_harvest_sys_id',
+      'created'
     ),
     filters = c(
       'field_wbddh_data_type' = 294,
@@ -30,10 +31,11 @@ get_ddh_datasets_list <- function(root_url = dkanr::get_url(),
   ddh_nids <- as.character(purrr::map(resp, 'nid'))
   md_refids <- as.character(purrr::map(resp, function(x) x[["field_wbddh_reference_id"]][["und"]][[1]][["value"]]))
   ddh_dataclass <- as.character(purrr::map(resp, function(x) x[["field_wbddh_data_class"]][["und"]][[1]][["tid"]]))
+  ddh_created <- as.character(purrr::map(resp, "created"))
   ddh_updated <- as.character(purrr::map(resp, function(x) x[["field_wbddh_modified_date"]][["und"]][[1]][["value"]]))
   md_internal_id <- as.character(purrr::map(resp, function(x) x[["field_ddh_harvest_sys_id"]][["und"]][[1]][["value"]]))
 
-  out <- data.frame(ddh_nids, md_refids, md_internal_id, ddh_dataclass, ddh_updated, stringsAsFactors = FALSE)
+  out <- data.frame(ddh_nids, md_refids, md_internal_id, ddh_dataclass, ddh_updated, ddh_created, stringsAsFactors = FALSE)
 
   return(out)
 }

--- a/R/get_ddh_records_status.R
+++ b/R/get_ddh_records_status.R
@@ -35,8 +35,8 @@ get_ddh_records_status <- function(mdlib_token, root_url = dkanr::get_url(),
   full_list <- dplyr::full_join(ddh_list, md_list, by = 'md_internal_id')
   full_list$status <- NA
   full_list$status[is.na(full_list$ddh_nids)] <- 'new'
-  full_list$status[!is.na(full_list$ddh_nids) & !is.na(full_list$md_internal_id)] <- 'current'
-  full_list$status[!is.na(full_list$ddh_nids) & is.na(full_list$md_internal_id)] <- 'old'
+  full_list$status[!is.na(full_list$ddh_nids) & !is.na(full_list$md_internal_updated)] <- 'current'
+  full_list$status[!is.na(full_list$ddh_nids) & is.na(full_list$md_internal_updated)] <- 'old'
 
   full_list <- dplyr::left_join(full_list, md_list_public, by = c('md_internal_refid' = 'md_external_refid'))
 
@@ -53,6 +53,11 @@ get_ddh_records_status <- function(mdlib_token, root_url = dkanr::get_url(),
 
   # Identify change of versions
   full_list$sync_status[full_list$md_refids != full_list$md_internal_refid] <- 'out of sync'
+
+  # Identify duplicates
+  full_list$oldest_timestamp <- ave(full_list$ddh_created, full_list$md_internal_id, FUN = min)
+  full_list$duplicate_status <- ifelse(full_list$ddh_created == full_list$oldest_timestamp, "original", "duplicate")
+  full_list$oldest_timestamp <- NULL
 
   return(full_list)
 }


### PR DESCRIPTION
(based on discussion for records status function in fin2ddh)

**1. Add logic to identify duplicates in `get_ddh_records_status()`** - handles #40
- compares `created` timestamps across records with the same `md_internal_id`
- classify records with older timestamps as "original" and others as "duplicates"

**2. Fix logic when classifying current/old records** - handles #62
- every record has a `md_internal_id` due to full join, previous logic would not catch old records
- filters on microdata timestamp instead