### PR TITLE
added constant metadadata field for economy coverage

### DIFF
--- a/R/add_constant_metadata_dataset.R
+++ b/R/add_constant_metadata_dataset.R
@@ -20,6 +20,6 @@ add_constant_metadata_dataset <- function(metadata_list) {
   metadata_list$field_ddh_harvest_src <- "Microdata"
   metadata_list$field_topic <- 'Topic not specified'
   metadata_list$field_wbddh_responsible <- "No"
-
+  metadata_list$field_wbddh_economy_coverage <- 'Economy Coverage not specified'
   return(metadata_list)
 }


### PR DESCRIPTION
Adding the mandatory “Economy Coverage” field to have a “Economy Coverage not specified” for all the microdatadatasets that the microdata harvester updates or adds. Currently when I try to manually change a microdata dataset, I get a mandatory field missing error, because “Economy Coverage” is not filled. I conferred with @cmachingauta that microdata datasets don’t have an “Economy Coverage” (High Income, low Income etc.) so “Economy Coverage not specified” is a good option.