### PR TITLE
Added check for Microdata API response

### DIFF
--- a/R/add_new_dataset.R
+++ b/R/add_new_dataset.R
@@ -28,7 +28,14 @@ add_new_dataset <- function(md_internal_id, md_token, master,
                                   master = master)
   # Format list
   temp <- map_md_to_ddh(temp)
+  
+  # Check if Microdata API returned enough information
+  if(is.null(temp$title) & is.null(temp$body)){
+    return("Microdata API didn't return Title or Description")
+  }
+  
   temp <- add_constant_metadata_dataset(temp)
+  
   # Add search_tags
   temp <- add_search_tags(metadata_list = temp,
                           id = md_internal_id,
@@ -46,6 +53,7 @@ add_new_dataset <- function(md_internal_id, md_token, master,
                                               ddh_fields = ddh_fields,
                                               lovs = lovs,
                                               root_url = root_url)
+
   # Push dataset to DDH
   resp_dat <- ddhconnect::create_dataset(body = json_dat,
                                          root_url = root_url,


### PR DESCRIPTION
These changes are to makesure that datasets are not pushed to DDH that don't have **Title** or **Body**. This occured because of the Microdata API in the past, and was logged as #89 and #87 .

Without this check, if the Microdata API doesn't render the mention metadata, the result would be http://ddh1stg.prod.acquia-sites.com/dataset/not-specified-5:

![image](https://user-images.githubusercontent.com/23365560/55296994-0eacb700-53ef-11e9-9da7-6b77f8a6a4cc.png)
