### PR TITLE
added country name mapping using iso_3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,5 +20,5 @@ Imports: assertthat,
     ddhconnect,
     gtools,
     stats
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2
 Depends: R (>= 2.10)

--- a/R/add_new_dataset.R
+++ b/R/add_new_dataset.R
@@ -9,6 +9,7 @@
 #' @param ddh_fields dataframe: table of all the data catalog fields by node type
 #' @param lovs dataframe: lookup table of the data catalog tids and values
 #' @param root_url character: Root URL to use for the API (Staging or Production)
+#' @param iso_3_df dataframe: Table of iso_3 codes and corresponding country names
 #'
 #' @return character
 #' @export
@@ -18,6 +19,7 @@ add_new_dataset <- function(md_internal_id, md_token, master,
                             ddh_fields = ddhconnect::get_fields(),
                             lovs = ddhconnect::get_lovs(),
                             root_url = dkanr::get_url(),
+                            iso_3_df = ddhconnect::get_iso3(),
                             credentials = list(cookie = dkanr::get_cookie(),
                                                token = dkanr::get_token())) {
 
@@ -27,6 +29,13 @@ add_new_dataset <- function(md_internal_id, md_token, master,
   # STEP 2: format raw metadata
   # Format list
   temp <- map_md_to_ddh(survey_mtdt)
+
+  # Use field_wbddh_reference_id to
+  ## - Extract ISO 3 code
+  ## - Map to country name using ddhconnect::get_iso3()
+  ## Consider using tryCatch for multiple ISO3s
+  iso_code <- stringr::str_extract(temp$field_wbddh_reference_id, "^\\w{3}")
+  temp$field_wbddh_country <- iso_3_df[which(iso_3_df$iso3 == iso_code), "country_name"]
 
   # Add correct data classification information
   temp <- add_data_classification(metadata_list = temp,

--- a/R/extract_md_metadata.R
+++ b/R/extract_md_metadata.R
@@ -23,6 +23,12 @@ extract_md_metadata <- function(metadata_in,
   for (i in seq_along(machine_names)) {
     mdlib_json_key <- unique(lookup$mdlib_json_field[lookup$ddh_machine_name == machine_names[i]])
     mdlib_json_key <- mdlib_json_key[!is.na(mdlib_json_key)]
+
+    # Skip for country field
+    if(machine_names[i] == "field_wbddh_country"){
+      next
+    }
+
     if (length(mdlib_json_key) == 0) {next}
 
     metadata_value <- find_metadata_value(mdlib_json_key, metadata_in)

--- a/R/update_existing_dataset.R
+++ b/R/update_existing_dataset.R
@@ -9,6 +9,7 @@
 #' @param ddh_fields dataframe: table of all the data catalog fields by node type
 #' @param lovs dataframe: lookup table of the data catalog tids and values
 #' @param root_url character: Root URL to use for the API (Staging or Production)
+#' @param iso_3_df dataframe: Table of iso_3 codes and corresponding country names
 #'
 #' @return character
 #' @export
@@ -18,6 +19,7 @@ update_existing_dataset <- function(md_internal_id, md_token, master,
                                     ddh_fields = ddhconnect::get_fields(),
                                     lovs = ddhconnect::get_lovs(),
                                     root_url = dkanr::get_url(),
+                                    iso_3_df = ddhconnect::get_iso3(),
                                     credentials = list(cookie = dkanr::get_cookie(),
                                                        token = dkanr::get_token())) {
 
@@ -26,6 +28,13 @@ update_existing_dataset <- function(md_internal_id, md_token, master,
 
   # STEP 2: format raw metadata
   temp <- map_md_to_ddh(survey_mtdt)
+
+  # Use field_wbddh_reference_id to
+  ## - Extract ISO 3 code
+  ## - Map to country name using ddhconnect::get_iso3()
+  ## Consider using tryCatch for multiple ISO3s
+  iso_code <- stringr::str_extract(temp$field_wbddh_reference_id, "^\\w{3}")
+  temp$field_wbddh_country <- iso_3_df[which(iso_3_df$iso3 == iso_code), "country_name"]
 
   # Add correct data classification information
   temp <- add_data_classification(metadata_list = temp,

--- a/man/add_new_dataset.Rd
+++ b/man/add_new_dataset.Rd
@@ -4,10 +4,16 @@
 \alias{add_new_dataset}
 \title{add_new_dataset()}
 \usage{
-add_new_dataset(md_internal_id, md_token, master,
-  ddh_fields = ddhconnect::get_fields(), lovs = ddhconnect::get_lovs(),
-  root_url = dkanr::get_url(), credentials = list(cookie =
-  dkanr::get_cookie(), token = dkanr::get_token()))
+add_new_dataset(
+  md_internal_id,
+  md_token,
+  master,
+  ddh_fields = ddhconnect::get_fields(),
+  lovs = ddhconnect::get_lovs(),
+  root_url = dkanr::get_url(),
+  iso_3_df = ddhconnect::get_iso3(),
+  credentials = list(cookie = dkanr::get_cookie(), token = dkanr::get_token())
+)
 }
 \arguments{
 \item{md_internal_id}{character: Microdata internal ID of the dataset to be added}
@@ -21,6 +27,8 @@ add_new_dataset(md_internal_id, md_token, master,
 \item{lovs}{dataframe: lookup table of the data catalog tids and values}
 
 \item{root_url}{character: Root URL to use for the API (Staging or Production)}
+
+\item{iso_3_df}{dataframe: Table of iso_3 codes and corresponding country names}
 
 \item{credentials}{list: DDH API authentication token and cookie}
 }

--- a/man/attach_resource_to_dataset.Rd
+++ b/man/attach_resource_to_dataset.Rd
@@ -5,9 +5,12 @@
 \title{attach_resource_to_dataset
 link resources to dataset}
 \usage{
-attach_resource_to_dataset(credentials = list(cookie =
-  dkanr::get_cookie(), token = dkanr::get_token()), body,
-  root_url = dkanr::get_url(), dataset_nid)
+attach_resource_to_dataset(
+  credentials = list(cookie = dkanr::get_cookie(), token = dkanr::get_token()),
+  body,
+  root_url = dkanr::get_url(),
+  dataset_nid
+)
 }
 \arguments{
 \item{credentials}{list: object returned by the get_credentials() function}

--- a/man/extract_md_metadata.Rd
+++ b/man/extract_md_metadata.Rd
@@ -4,9 +4,11 @@
 \alias{extract_md_metadata}
 \title{extract_md_metadata}
 \usage{
-extract_md_metadata(metadata_in,
+extract_md_metadata(
+  metadata_in,
   metadata_out = mdlibtoddh::md_placeholder,
-  lookup = mdlibtoddh::lookup)
+  lookup = mdlibtoddh::lookup
+)
 }
 \arguments{
 \item{metadata_in}{list: The output of mdlibconnect::get_survey_metadata}

--- a/man/format_md_metadata.Rd
+++ b/man/format_md_metadata.Rd
@@ -4,12 +4,13 @@
 \alias{format_md_metadata}
 \title{format_md_metadata}
 \usage{
-format_md_metadata(metadata_in,
-  date_fields = c("field_wbddh_modified_date",
-  "field_wbddh_release_date"), text_fields = c("body",
-  "field_wbddh_citation_text", "field_wbddh_disclaimer",
-  "field_wbddh_questionnaires", "field_wbddh_sampling_procedure",
-  "field_wbddh_series_information", "field_wbddh_supervision"))
+format_md_metadata(
+  metadata_in,
+  date_fields = c("field_wbddh_modified_date", "field_wbddh_release_date"),
+  text_fields = c("body", "field_wbddh_citation_text", "field_wbddh_disclaimer",
+    "field_wbddh_questionnaires", "field_wbddh_sampling_procedure",
+    "field_wbddh_series_information", "field_wbddh_supervision")
+)
 }
 \arguments{
 \item{metadata_in}{list: flattened list of metadata}

--- a/man/get_ddh_datasets_list.Rd
+++ b/man/get_ddh_datasets_list.Rd
@@ -4,9 +4,10 @@
 \alias{get_ddh_datasets_list}
 \title{get_ddh_datasets_list}
 \usage{
-get_ddh_datasets_list(root_url = dkanr::get_url(),
-  credentials = list(cookie = dkanr::get_cookie(), token =
-  dkanr::get_token()))
+get_ddh_datasets_list(
+  root_url = dkanr::get_url(),
+  credentials = list(cookie = dkanr::get_cookie(), token = dkanr::get_token())
+)
 }
 \arguments{
 \item{root_url}{character: API root URL}

--- a/man/get_ddh_records_status.Rd
+++ b/man/get_ddh_records_status.Rd
@@ -4,9 +4,11 @@
 \alias{get_ddh_records_status}
 \title{get_ddh_records_status}
 \usage{
-get_ddh_records_status(mdlib_token, root_url = dkanr::get_url(),
-  credentials = list(cookie = dkanr::get_cookie(), token =
-  dkanr::get_token()))
+get_ddh_records_status(
+  mdlib_token,
+  root_url = dkanr::get_url(),
+  credentials = list(cookie = dkanr::get_cookie(), token = dkanr::get_token())
+)
 }
 \arguments{
 \item{mdlib_token}{character: Microdatalib API authentication token}

--- a/man/handle_array_metadata.Rd
+++ b/man/handle_array_metadata.Rd
@@ -4,9 +4,11 @@
 \alias{handle_array_metadata}
 \title{handle_array_metadata}
 \usage{
-handle_array_metadata(metadata_in,
+handle_array_metadata(
+  metadata_in,
   metadata_out = mdlibtoddh::md_placeholder,
-  lookup = mdlibtoddh::lookup)
+  lookup = mdlibtoddh::lookup
+)
 }
 \arguments{
 \item{metadata_in}{list: The output of mdlibconnect::get_survey_metadata}

--- a/man/pass_blank_values.Rd
+++ b/man/pass_blank_values.Rd
@@ -4,8 +4,13 @@
 \alias{pass_blank_values}
 \title{pass_blank_values()}
 \usage{
-pass_blank_values(node_id, dataset_metadata, metadata_list, root_url,
-  credentials)
+pass_blank_values(
+  node_id,
+  dataset_metadata,
+  metadata_list,
+  root_url,
+  credentials
+)
 }
 \arguments{
 \item{node_id}{character: DDH node ID of the dataset to be updated}

--- a/man/test_created_dataset.Rd
+++ b/man/test_created_dataset.Rd
@@ -4,10 +4,13 @@
 \alias{test_created_dataset}
 \title{test_created_dataset}
 \usage{
-test_created_dataset(dataset_metadata, metadata_list,
-  lovs = ddhconnect::get_lovs(), root_url = dkanr::get_url(),
-  credentials = list(cookie = dkanr::get_cookie(), token =
-  dkanr::get_token()))
+test_created_dataset(
+  dataset_metadata,
+  metadata_list,
+  lovs = ddhconnect::get_lovs(),
+  root_url = dkanr::get_url(),
+  credentials = list(cookie = dkanr::get_cookie(), token = dkanr::get_token())
+)
 }
 \arguments{
 \item{dataset_metadata}{character: The dataset metadata, returned from ddhconnect::get_metadata()}

--- a/man/update_existing_dataset.Rd
+++ b/man/update_existing_dataset.Rd
@@ -4,10 +4,15 @@
 \alias{update_existing_dataset}
 \title{update_existing_dataset()}
 \usage{
-update_existing_dataset(md_internal_id, md_token, master,
-  ddh_fields = ddhconnect::get_fields(), lovs = ddhconnect::get_lovs(),
-  root_url = dkanr::get_url(), credentials = list(cookie =
-  dkanr::get_cookie(), token = dkanr::get_token()))
+update_existing_dataset(
+  md_internal_id,
+  md_token,
+  master,
+  ddh_fields = ddhconnect::get_fields(),
+  lovs = ddhconnect::get_lovs(),
+  root_url = dkanr::get_url(),
+  credentials = list(cookie = dkanr::get_cookie(), token = dkanr::get_token())
+)
 }
 \arguments{
 \item{md_internal_id}{character: Microdata internal ID of the dataset to be added}


### PR DESCRIPTION
- Using the the `field_wbddh_reference_id` field, which extracts the `idno` from Microdata surveys:
[example](https://microdata.worldbank.org/index.php/api/catalog/1000?id_format=id&format=json) 
![image](https://user-images.githubusercontent.com/23365560/80893689-91630e00-8ca2-11ea-9781-a5a371011e8d.png)

To extract the iso_3 code for the survey, then use the iso_3 code to find the ddh specific country name from the `ddhconnect::get_iso()` function

**This is the last fix to prepare for automation, but we need to account for surveys which have multiple countries**